### PR TITLE
Refactor line follow node

### DIFF
--- a/Nodes/LineFollowNode.cpp
+++ b/Nodes/LineFollowNode.cpp
@@ -100,11 +100,11 @@ void LineFollowNode::processMessage(const Message* msg)
     case MessageType::StateMessage:
     {
       const StateMessage* stateMsg = static_cast<const StateMessage*>(msg);
-      m_VesselHeading = stateMsg->heading();
-      m_VesselLat = stateMsg->latitude();
-      m_VesselLon = stateMsg->longitude();
-      m_VesselSpeed = stateMsg->speed();
-      m_VesselCourse = stateMsg->course();
+      m_Heading = stateMsg->heading();
+      m_Latitude = stateMsg->latitude();
+      m_Longitude = stateMsg->longitude();
+      m_Speed = stateMsg->speed();
+      m_Course = stateMsg->course();
     }
     break;
     case MessageType::WindState:
@@ -132,7 +132,7 @@ void LineFollowNode::processMessage(const Message* msg)
   }
 }
 
-double LineFollowNode::calculateAngleOfDesiredTrajectory(VesselStateMsg* msg)
+double LineFollowNode::calculateAngleOfDesiredTrajectory()
 {
   int earthRadius = 6371000;
 
@@ -146,10 +146,10 @@ double LineFollowNode::calculateAngleOfDesiredTrajectory(VesselStateMsg* msg)
       earthRadius * sin(Utility::degreeToRadian(m_nextWaypointLat))};
 
       double M[2][3] =
-      {   {-sin(Utility::degreeToRadian(msg->longitude() )), cos(Utility::degreeToRadian(msg->longitude() )), 0},
-      {-cos(Utility::degreeToRadian(msg->longitude() ))*sin(Utility::degreeToRadian(msg->latitude() )),
-        -sin(Utility::degreeToRadian(msg->longitude() ))*sin(Utility::degreeToRadian(msg->latitude() )),
-        cos(Utility::degreeToRadian(msg->latitude() ))}};
+      {   {-sin(Utility::degreeToRadian(m_Latitude)), cos(Utility::degreeToRadian(m_Latitude )), 0},
+      {-cos(Utility::degreeToRadian(m_Latitude ))*sin(Utility::degreeToRadian(m_Latitude )),
+        -sin(Utility::degreeToRadian(m_Latitude ))*sin(Utility::degreeToRadian(m_Latitude )),
+        cos(Utility::degreeToRadian(m_Latitude ))}};
 
         std::array<double, 3> bMinusA = { nextWPCoord[0]-prevWPCoord[0], nextWPCoord[1]-prevWPCoord[1], nextWPCoord[2]-prevWPCoord[2]};
 
@@ -277,8 +277,8 @@ double LineFollowNode::calculateAngleOfDesiredTrajectory(VesselStateMsg* msg)
           if(waypMsg->prevId() == 0) //Set previous waypoint to boat position
           {
             m_prevWaypointId = 0;
-            m_prevWaypointLon = m_VesselLon;
-            m_prevWaypointLat = m_VesselLat;
+            m_prevWaypointLon = m_Longitude;
+            m_prevWaypointLat = m_Latitude;
             m_prevWaypointDeclination = 0;
             m_prevWaypointRadius = 15;
           }

--- a/Nodes/LineFollowNode.cpp
+++ b/Nodes/LineFollowNode.cpp
@@ -186,7 +186,7 @@ double LineFollowNode::calculateAngleOfDesiredTrajectory()
         double signedDistance = Utility::calculateSignedDistanceToLine(m_nextWaypointLon, m_nextWaypointLat, m_prevWaypointLon,
           m_prevWaypointLat, msg->longitude(), msg->latitude());
           int maxTackDistance = 40; //'r'
-          double phi = calculateAngleOfDesiredTrajectory(msg);
+          double phi = calculateAngleOfDesiredTrajectory();
           double desiredHeading = phi + (2 * (M_PI / 4)/M_PI) * atan(signedDistance/maxTackDistance); //heading to smoothly join the line
           desiredHeading = Utility::limitRadianAngleRange(desiredHeading);
           //---------------------

--- a/Nodes/LineFollowNode.cpp
+++ b/Nodes/LineFollowNode.cpp
@@ -156,20 +156,13 @@ double LineFollowNode::calculateAngleOfDesiredTrajectory()
         return phi;
       }
 
-      //Martins: Send WindStateMsg here And trie to break to smaller components
       void LineFollowNode::calculateActuatorPos(const WindStateMsg* msg)
       {
-
-        //Martins: WindStateMsg already has a trueWindDirection -- i think that should be used instead.
-        //Martins: Save the state of the StateMessage
-
         /* add pi because trueWindDirection is originally origin of wind but algorithm need direction*/
         double trueWindDirection_radian = Utility::degreeToRadian(msg->trueWindDirection())+M_PI;
 
-        //Martins: Send WindStateMsg
         setPrevWaypointToBoatPos();
 
-        //Martins: Use the saved state of StateMessage and WaypointDataMsg
         //GET DIRECTION--------
         double currentHeading = getHeading(m_Course, m_Heading, m_Speed, false, false);
         double currentHeading_radian = Utility::degreeToRadian(currentHeading);
@@ -254,11 +247,9 @@ double LineFollowNode::calculateAngleOfDesiredTrajectory()
           m_dbLogger.log(msg, rudderCommand_norm, sailCommand_norm, 0, 0, distanceToNextWaypoint, bearingToNextWaypoint, desiredHeading, m_tack, getGoingStarboard(), m_nextWaypointId, msg->trueWindDirection(), false,timestamp_str);
         }
 
-        //Martins: Pass only WaypointDataMsg here
         void LineFollowNode::setPrevWaypointData(WaypointDataMsg* waypMsg)
         {
 
-          //Martins: Use the saved state of the StateMessage
           if(waypMsg->prevId() == 0) //Set previous waypoint to boat position
           {
             m_prevWaypointId = 0;
@@ -342,7 +333,6 @@ double LineFollowNode::calculateAngleOfDesiredTrajectory()
           else return false;
         }
 
-        //Martins: Use the StateMessage and WaypointDataMsg Saved so do not send any message type here
         void LineFollowNode::setPrevWaypointToBoatPos() //If boat passed waypoint or enters it, set new line from boat to waypoint.
         {                                                                  //Used if boat has to stay within waypoint for a set amount of time.
           double distanceAfterWaypoint = Utility::calculateWaypointsOrthogonalLine(m_nextWaypointLon, m_nextWaypointLat, m_prevWaypointLon,

--- a/Nodes/LineFollowNode.cpp
+++ b/Nodes/LineFollowNode.cpp
@@ -1,24 +1,26 @@
- /****************************************************************************************
- *
- * File:
- * 		LineFollowNode.cpp
- *
- * Purpose:
- *		This class computes the actuator positions of the boat in order to follow
- *    lines given by the waypoints.
- *
- * Developer Notes: algorithm inspired and modified from Luc Jaulin and
- *    Fabrice Le Bars  "An Experimental Validation of a Robust Controller with the VAIMOS
- *    Autonomous Sailboat" and "Modeling and Control for an Autonomous Sailboat: A
- *    Case Study" from Jon Melin, Kjell Dahl and Matia Waller
- *
- *
- ***************************************************************************************/
+/****************************************************************************************
+*
+* File:
+* 		LineFollowNode.cpp
+*
+* Purpose:
+*		This class computes the actuator positions of the boat in order to follow
+*    lines given by the waypoints.
+*
+* Developer Notes: algorithm inspired and modified from Luc Jaulin and
+*    Fabrice Le Bars  "An Experimental Validation of a Robust Controller with the VAIMOS
+*    Autonomous Sailboat" and "Modeling and Control for an Autonomous Sailboat: A
+*    Case Study" from Jon Melin, Kjell Dahl and Matia Waller
+*
+*
+***************************************************************************************/
 
 #include "LineFollowNode.h"
 #include "Messages/ActuatorPositionMsg.h"
 #include "Messages/ExternalControlMsg.h"
 #include "Messages/CourseDataMsg.h"
+#include "Messages/StateMessage.h"
+#include "Messages/WindStateMsg.h"
 #include "Math/Utility.h"
 #include "SystemServices/SysClock.h"
 #include <math.h>
@@ -35,304 +37,337 @@ FILE* file = fopen("./gps.txt", "w");
 
 LineFollowNode::LineFollowNode(MessageBus& msgBus, DBHandler& db)
 :  Node(NodeID::SailingLogic, msgBus), m_db(db), m_dbLogger(5, db),
-    m_nextWaypointId(0),
-    m_nextWaypointLon(0),
-    m_nextWaypointLat(0),
-    m_nextWaypointDeclination(0),
-    m_nextWaypointRadius(0),
-    m_prevWaypointId(0),
-    m_prevWaypointLon(0),
-    m_prevWaypointLat(0),
-    m_prevWaypointDeclination(0),
-    m_prevWaypointRadius(0),
-    m_externalControlActive(false),
-    m_tackingDirection(1)
+m_nextWaypointId(0),
+m_nextWaypointLon(0),
+m_nextWaypointLat(0),
+m_nextWaypointDeclination(0),
+m_nextWaypointRadius(0),
+m_prevWaypointId(0),
+m_prevWaypointLon(0),
+m_prevWaypointLat(0),
+m_prevWaypointDeclination(0),
+m_prevWaypointRadius(0),
+m_externalControlActive(false),
+m_tackingDirection(1)
 {
-    msgBus.registerNode(*this, MessageType::VesselState);
-    msgBus.registerNode(*this, MessageType::WaypointData);
-    msgBus.registerNode(*this, MessageType::ExternalControl);
+  //To remove
+  msgBus.registerNode(*this, MessageType::VesselState);
 
-    m_maxCommandAngle = M_PI / 6;
-    m_maxSailAngle = M_PI / 4.2f;
-    m_minSailAngle = M_PI / 32.0f;
-    m_tackAngle = 0.872665; //50°
+  msgBus.registerNode(*this, MessageType::StateMessage);
+  msgBus.registerNode(*this, MessageType::WindState);
+  msgBus.registerNode(*this, MessageType::WaypointData);
+  msgBus.registerNode(*this, MessageType::ExternalControl);
 
-    fprintf( file, "%s,%ss,%s\n", "id", "latitude", "longitude" );
-    fflush( file );
+  m_maxCommandAngle = M_PI / 6;
+  m_maxSailAngle = M_PI / 4.2f;
+  m_minSailAngle = M_PI / 32.0f;
+  m_tackAngle = 0.872665; //50°
+
+  fprintf( file, "%s,%ss,%s\n", "id", "latitude", "longitude" );
+  fflush( file );
 }
 
 bool LineFollowNode::init()
 {
-    setupRudderCommand();
-    setupSailCommand();
-    twdBufferMaxSize = m_db.retrieveCellAsInt("buffer_config", "1", "true_wind");
-	if(twdBufferMaxSize == 0)
-		twdBufferMaxSize = DEFAULT_TWD_BUFFERSIZE;
-	m_dbLogger.startWorkerThread();
-    return true;
+  setupRudderCommand();
+  setupSailCommand();
+  twdBufferMaxSize = m_db.retrieveCellAsInt("buffer_config", "1", "true_wind");
+  if(twdBufferMaxSize == 0)
+  twdBufferMaxSize = DEFAULT_TWD_BUFFERSIZE;
+  m_dbLogger.startWorkerThread();
+  return true;
 }
 
 void LineFollowNode::processMessage(const Message* msg)
 {
-    static int i = 0;
-    MessageType type = msg->messageType();
+  static int i = 0;
+  MessageType type = msg->messageType();
 
-	switch(type)
-	{
+  switch(type)
+  {
     case MessageType::ExternalControl:
-         m_externalControlActive = ((ExternalControlMsg*)msg)->externalControlActive();
-        break;
-	case MessageType::VesselState:
-        if(!m_externalControlActive)
-        {
-             calculateActuatorPos((VesselStateMsg*)msg);
-        }
-        {
-        VesselStateMsg* state = (VesselStateMsg*)msg;
-        fprintf( file, "%d,%f,%f\n", i, state->latitude(), state->longitude() );
-        }
-		break;
-	case MessageType::WaypointData:
-        {
-            WaypointDataMsg* waypMsg = (WaypointDataMsg*)msg;
-            m_nextWaypointId = waypMsg->nextId();
-            m_nextWaypointLon = waypMsg->nextLongitude();
-            m_nextWaypointLat = waypMsg->nextLatitude();
-            m_nextWaypointDeclination = waypMsg->nextDeclination();
-            m_nextWaypointRadius = waypMsg->nextRadius();
-            setPrevWaypointData(waypMsg, (VesselStateMsg*)msg);
-        }
-		break;
-	default:
-		return;
-	}
+    m_externalControlActive = ((ExternalControlMsg*)msg)->externalControlActive();
+    break;
+    case MessageType::VesselState:
+    if(!m_externalControlActive)
+    {
+      calculateActuatorPos((VesselStateMsg*)msg);
+    }else{
+      VesselStateMsg* state = (VesselStateMsg*)msg;
+      fprintf( file, "%d,%f,%f\n", i, state->latitude(), state->longitude() );
+    }
+    break;
+    case MessageType::StateMessage:
+    {
+      const StateMessage* stateMsg = static_cast<const StateMessage*>(msg);
+      m_VesselHeading = stateMsg->heading();
+      m_VesselLat = stateMsg->latitude();
+      m_VesselLon = stateMsg->longitude();
+      m_VesselSpeed = stateMsg->speed();
+      m_VesselCourse = stateMsg->course();
+    }
+    break;
+    case MessageType::WindState:
+    {
+      const WindStateMsg* windStateMsg = static_cast<const WindStateMsg*>(msg);
+      m_trueWindSpeed = windStateMsg->trueWindSpeed();
+      m_trueWindDir = windStateMsg->trueWindDirection();
+      m_apparentWindSpeed = windStateMsg->apparentWindSpeed();
+      m_apparentWindDir = windStateMsg->apparentWindDirection();
+    }
+    break;
+    case MessageType::WaypointData:
+    {
+      WaypointDataMsg* waypMsg = (WaypointDataMsg*)msg;
+      m_nextWaypointId = waypMsg->nextId();
+      m_nextWaypointLon = waypMsg->nextLongitude();
+      m_nextWaypointLat = waypMsg->nextLatitude();
+      m_nextWaypointDeclination = waypMsg->nextDeclination();
+      m_nextWaypointRadius = waypMsg->nextRadius();
+      setPrevWaypointData(waypMsg, (VesselStateMsg*)msg);
+    }
+    break;
+    default:
+    return;
+  }
 }
 
 double LineFollowNode::calculateAngleOfDesiredTrajectory(VesselStateMsg* msg)
 {
-    int earthRadius = 6371000;
+  int earthRadius = 6371000;
 
-    std::array<double, 3> prevWPCoord =
-     {  earthRadius * cos(Utility::degreeToRadian(m_prevWaypointLat)) * cos(Utility::degreeToRadian(m_prevWaypointLon)),
-        earthRadius * cos(Utility::degreeToRadian(m_prevWaypointLat)) * sin(Utility::degreeToRadian(m_prevWaypointLon)),
-        earthRadius * sin(Utility::degreeToRadian(m_prevWaypointLat))};
+  std::array<double, 3> prevWPCoord =
+  {  earthRadius * cos(Utility::degreeToRadian(m_prevWaypointLat)) * cos(Utility::degreeToRadian(m_prevWaypointLon)),
+    earthRadius * cos(Utility::degreeToRadian(m_prevWaypointLat)) * sin(Utility::degreeToRadian(m_prevWaypointLon)),
+    earthRadius * sin(Utility::degreeToRadian(m_prevWaypointLat))};
     std::array<double, 3> nextWPCoord =
-     {  earthRadius * cos(Utility::degreeToRadian(m_nextWaypointLat)) * cos(Utility::degreeToRadian(m_nextWaypointLon)),
-        earthRadius * cos(Utility::degreeToRadian(m_nextWaypointLat)) * sin(Utility::degreeToRadian(m_nextWaypointLon)),
-        earthRadius * sin(Utility::degreeToRadian(m_nextWaypointLat))};
+    {  earthRadius * cos(Utility::degreeToRadian(m_nextWaypointLat)) * cos(Utility::degreeToRadian(m_nextWaypointLon)),
+      earthRadius * cos(Utility::degreeToRadian(m_nextWaypointLat)) * sin(Utility::degreeToRadian(m_nextWaypointLon)),
+      earthRadius * sin(Utility::degreeToRadian(m_nextWaypointLat))};
 
-    double M[2][3] =
-    {   {-sin(Utility::degreeToRadian(msg->longitude() )), cos(Utility::degreeToRadian(msg->longitude() )), 0},
-        {-cos(Utility::degreeToRadian(msg->longitude() ))*sin(Utility::degreeToRadian(msg->latitude() )),
-         -sin(Utility::degreeToRadian(msg->longitude() ))*sin(Utility::degreeToRadian(msg->latitude() )),
-         cos(Utility::degreeToRadian(msg->latitude() ))}};
+      double M[2][3] =
+      {   {-sin(Utility::degreeToRadian(msg->longitude() )), cos(Utility::degreeToRadian(msg->longitude() )), 0},
+      {-cos(Utility::degreeToRadian(msg->longitude() ))*sin(Utility::degreeToRadian(msg->latitude() )),
+        -sin(Utility::degreeToRadian(msg->longitude() ))*sin(Utility::degreeToRadian(msg->latitude() )),
+        cos(Utility::degreeToRadian(msg->latitude() ))}};
 
-    std::array<double, 3> bMinusA = { nextWPCoord[0]-prevWPCoord[0], nextWPCoord[1]-prevWPCoord[1], nextWPCoord[2]-prevWPCoord[2]};
+        std::array<double, 3> bMinusA = { nextWPCoord[0]-prevWPCoord[0], nextWPCoord[1]-prevWPCoord[1], nextWPCoord[2]-prevWPCoord[2]};
 
-                        // 2x3 * 1x3
-    double phi = atan2(M[0][0]*bMinusA[0] + M[0][1]*bMinusA[1] + M[0][2]*bMinusA[2],   M[1][0]*bMinusA[0] + M[1][1]*bMinusA[1] + M[1][2]*bMinusA[2]);
+        // 2x3 * 1x3
+        double phi = atan2(M[0][0]*bMinusA[0] + M[0][1]*bMinusA[1] + M[0][2]*bMinusA[2],   M[1][0]*bMinusA[0] + M[1][1]*bMinusA[1] + M[1][2]*bMinusA[2]);
 
-    return phi;
-}
+        return phi;
+      }
 
-void LineFollowNode::calculateActuatorPos(VesselStateMsg* msg)
-{
-    if(not msg->gpsOnline())
-    {
-        Logger::error("GPS not online, using values from last iteration");
-        return;
-    }
-
-    double trueWindDirection = Utility::getTrueWindDirection(msg->windDir(), msg->windSpeed(),
-                                                             msg->speed(), msg->compassHeading(), twdBuffer, twdBufferMaxSize);
-    /* add pi because trueWindDirection is originally origin of wind but algorithm need direction*/
-    double trueWindDirection_radian = Utility::degreeToRadian(trueWindDirection)+M_PI;
-
-    setPrevWaypointToBoatPos(msg);
-
-    //GET DIRECTION--------
-    double currentHeading = getHeading(msg->gpsHeading(), msg->compassHeading(), msg->speed(), false, false);
-    double currentHeading_radian = Utility::degreeToRadian(currentHeading);
-    double signedDistance = Utility::calculateSignedDistanceToLine(m_nextWaypointLon, m_nextWaypointLat, m_prevWaypointLon,
-                                                                   m_prevWaypointLat, msg->longitude(), msg->latitude());
-    int maxTackDistance = 40; //'r'
-    double phi = calculateAngleOfDesiredTrajectory(msg);
-    double desiredHeading = phi + (2 * (M_PI / 4)/M_PI) * atan(signedDistance/maxTackDistance); //heading to smoothly join the line
-    desiredHeading = Utility::limitRadianAngleRange(desiredHeading);
-    //---------------------
-
-    //Change tacking direction when reaching max distance
-    if(abs(signedDistance) > maxTackDistance)
-    {
-        m_tackingDirection = -Utility::sgn(signedDistance);
-    }
-    //--------------------------------------------------
-
-    //Check if tacking is needed-----
-    if( (cos(trueWindDirection_radian - desiredHeading) + cos(m_tackAngle) < 0) || (cos(trueWindDirection_radian - phi) + cos(m_tackAngle) < 0))
-    {
-        if(!m_tack) /* initialize tacking direction */
+      //Martins: Send WindStateMsg here And trie to break to smaller components
+      void LineFollowNode::calculateActuatorPos(VesselStateMsg* msg)
+      {
+        //Remove
+        if(not msg->gpsOnline())
         {
-            m_tackingDirection = -Utility::sgn(currentHeading_radian-(fmod(trueWindDirection_radian+M_PI, 2*M_PI) - M_PI));
-            m_tack = true;
+          Logger::error("GPS not online, using values from last iteration");
+          return;
         }
 
-        desiredHeading = M_PI + trueWindDirection_radian - m_tackingDirection * m_tackAngle;/* sail around the wind direction */
-        desiredHeading = Utility::limitRadianAngleRange(desiredHeading);
-    }
-    else
-    {
-        m_tack = false;
-    }
-    //-------------------------------
+        //Martins: WindStateMsg already has a trueWindDirection -- i think that should be used instead.
+        //Martins: Save the state of the StateMessage
+        double trueWindDirection = Utility::getTrueWindDirection(msg->windDir(), msg->windSpeed(),
+        msg->speed(), msg->compassHeading(), twdBuffer, twdBufferMaxSize);
+        /* add pi because trueWindDirection is originally origin of wind but algorithm need direction*/
+        double trueWindDirection_radian = Utility::degreeToRadian(trueWindDirection)+M_PI;
 
-    double rudderCommand, sailCommand;
+        //Martins: Send WindStateMsg
+        setPrevWaypointToBoatPos(msg);
 
-    //SET RUDDER-------
-    if(cos(currentHeading_radian - desiredHeading) < 0) //if boat heading is too far away from desired heading
-    {
-        rudderCommand = -Utility::sgn(msg->speed()) * m_maxCommandAngle * Utility::sgn(sin(currentHeading_radian - desiredHeading));
-    }
-    else
-    {
-        rudderCommand = -Utility::sgn(msg->speed()) * m_maxCommandAngle * sin(currentHeading_radian - desiredHeading);
-    }
-    //-----------------
+        //Martins: Use the saved state of StateMessage and WaypointDataMsg
+        //GET DIRECTION--------
+        double currentHeading = getHeading(msg->gpsHeading(), msg->compassHeading(), msg->speed(), false, false);
+        double currentHeading_radian = Utility::degreeToRadian(currentHeading);
+        double signedDistance = Utility::calculateSignedDistanceToLine(m_nextWaypointLon, m_nextWaypointLat, m_prevWaypointLon,
+          m_prevWaypointLat, msg->longitude(), msg->latitude());
+          int maxTackDistance = 40; //'r'
+          double phi = calculateAngleOfDesiredTrajectory(msg);
+          double desiredHeading = phi + (2 * (M_PI / 4)/M_PI) * atan(signedDistance/maxTackDistance); //heading to smoothly join the line
+          desiredHeading = Utility::limitRadianAngleRange(desiredHeading);
+          //---------------------
 
-    //SET SAIL---------
-    double apparentWindDirection = Utility::getApparentWindDirection(msg->windDir(),
-                    msg->windSpeed(), msg->speed(), currentHeading_radian, trueWindDirection_radian)*M_PI/180;
+          //Change tacking direction when reaching max distance
+          if(abs(signedDistance) > maxTackDistance)
+          {
+            m_tackingDirection = -Utility::sgn(signedDistance);
+          }
+          //--------------------------------------------------
 
-    apparentWindDirection = ( (apparentWindDirection+M_PI>M_PI) ? (apparentWindDirection-M_PI):(apparentWindDirection+M_PI) );
+          //Check if tacking is needed-----
+          if( (cos(trueWindDirection_radian - desiredHeading) + cos(m_tackAngle) < 0) || (cos(trueWindDirection_radian - phi) + cos(m_tackAngle) < 0))
+          {
+            if(!m_tack) /* initialize tacking direction */
+            {
+              m_tackingDirection = -Utility::sgn(currentHeading_radian-(fmod(trueWindDirection_radian+M_PI, 2*M_PI) - M_PI));
+              m_tack = true;
+            }
 
-    sailCommand = fabs(((m_minSailAngle - m_maxSailAngle) / M_PI) * fabs(apparentWindDirection) + m_maxSailAngle);/*!!! on some pc abs only ouptut an int (ubuntu 14.04 gcc 4.9.3)*/
+            desiredHeading = M_PI + trueWindDirection_radian - m_tackingDirection * m_tackAngle;/* sail around the wind direction */
+            desiredHeading = Utility::limitRadianAngleRange(desiredHeading);
+          }
+          else
+          {
+            m_tack = false;
+          }
+          //-------------------------------
 
-    if (cos(apparentWindDirection+M_PI) + cos(m_maxSailAngle) <0 )
-    {
-       sailCommand = m_minSailAngle;
-    }
+          double rudderCommand, sailCommand;
 
-    //------------------
-    int rudderCommand_norm = m_rudderCommand.getCommand(rudderCommand/NORM_RUDDER_COMMAND);
-    int sailCommand_norm = m_sailCommand.getCommand(sailCommand/NORM_SAIL_COMMAND);
+          //SET RUDDER-------
+          if(cos(currentHeading_radian - desiredHeading) < 0) //if boat heading is too far away from desired heading
+          {
+            rudderCommand = -Utility::sgn(msg->speed()) * m_maxCommandAngle * Utility::sgn(sin(currentHeading_radian - desiredHeading));
+          }
+          else
+          {
+            rudderCommand = -Utility::sgn(msg->speed()) * m_maxCommandAngle * sin(currentHeading_radian - desiredHeading);
+          }
+          //-----------------
+
+          //USE WindStateMsg apparentWindDirection
+          //SET SAIL---------
+          double apparentWindDirection = Utility::getApparentWindDirection(msg->windDir(),
+          msg->windSpeed(), msg->speed(), currentHeading_radian, trueWindDirection_radian)*M_PI/180;
+
+          apparentWindDirection = ( (apparentWindDirection+M_PI>M_PI) ? (apparentWindDirection-M_PI):(apparentWindDirection+M_PI) );
+
+          sailCommand = fabs(((m_minSailAngle - m_maxSailAngle) / M_PI) * fabs(apparentWindDirection) + m_maxSailAngle);/*!!! on some pc abs only ouptut an int (ubuntu 14.04 gcc 4.9.3)*/
+
+          if (cos(apparentWindDirection+M_PI) + cos(m_maxSailAngle) <0 )
+          {
+            sailCommand = m_minSailAngle;
+          }
+
+          //------------------
+          int rudderCommand_norm = m_rudderCommand.getCommand(rudderCommand/NORM_RUDDER_COMMAND);
+          int sailCommand_norm = m_sailCommand.getCommand(sailCommand/NORM_SAIL_COMMAND);
 
 
-    //Send messages----
-    MessagePtr actuatorMsg = std::make_unique<ActuatorPositionMsg>(rudderCommand_norm, sailCommand_norm);
-    m_MsgBus.sendMessage(std::move(actuatorMsg));
+          //Send messages----
+          MessagePtr actuatorMsg = std::make_unique<ActuatorPositionMsg>(rudderCommand_norm, sailCommand_norm);
+          m_MsgBus.sendMessage(std::move(actuatorMsg));
 
-    //------------------
+          //------------------
 
-    double bearingToNextWaypoint = CourseMath::calculateBTW(msg->longitude(), msg->latitude(), m_nextWaypointLon, m_nextWaypointLat); //calculated for database
-    double distanceToNextWaypoint = CourseMath::calculateDTW(msg->longitude(), msg->latitude(), m_nextWaypointLon, m_nextWaypointLat);
+          double bearingToNextWaypoint = CourseMath::calculateBTW(msg->longitude(), msg->latitude(), m_nextWaypointLon, m_nextWaypointLat); //calculated for database
+          double distanceToNextWaypoint = CourseMath::calculateDTW(msg->longitude(), msg->latitude(), m_nextWaypointLon, m_nextWaypointLat);
 
-    MessagePtr courseMsg = std::make_unique<CourseDataMsg>(trueWindDirection, distanceToNextWaypoint, bearingToNextWaypoint);
-    m_MsgBus.sendMessage(std::move(courseMsg));
+          MessagePtr courseMsg = std::make_unique<CourseDataMsg>(trueWindDirection, distanceToNextWaypoint, bearingToNextWaypoint);
+          m_MsgBus.sendMessage(std::move(courseMsg));
 
-    //create timestamp----
-    std::string timestamp_str=SysClock::timeStampStr();
-    timestamp_str+=".";
-    timestamp_str+= std::to_string(SysClock::millis());
-    //--------------------
+          //create timestamp----
+          std::string timestamp_str=SysClock::timeStampStr();
+          timestamp_str+=".";
+          timestamp_str+= std::to_string(SysClock::millis());
+          //--------------------
 
-    m_dbLogger.log(msg, rudderCommand_norm, sailCommand_norm, 0, 0, distanceToNextWaypoint, bearingToNextWaypoint, desiredHeading, m_tack, getGoingStarboard(), m_nextWaypointId, trueWindDirection, false,timestamp_str);
-}
+          m_dbLogger.log(msg, rudderCommand_norm, sailCommand_norm, 0, 0, distanceToNextWaypoint, bearingToNextWaypoint, desiredHeading, m_tack, getGoingStarboard(), m_nextWaypointId, trueWindDirection, false,timestamp_str);
+        }
 
-void LineFollowNode::setPrevWaypointData(WaypointDataMsg* waypMsg, VesselStateMsg* vesselMsg)
-{
-    if(waypMsg->prevId() == 0) //Set previous waypoint to boat position
-    {
-        m_prevWaypointId = 0;
-        m_prevWaypointLon = vesselMsg->longitude();
-        m_prevWaypointLat = vesselMsg->latitude();
-        m_prevWaypointDeclination = 0;
-        m_prevWaypointRadius = 15;
-    }
-    else //Set previous waypoint to previously harvested waypoint
-    {
-        m_prevWaypointId = waypMsg->prevId();
-        m_prevWaypointLon = waypMsg->prevLongitude();
-        m_prevWaypointLat = waypMsg->prevLatitude();
-        m_prevWaypointDeclination = waypMsg->prevDeclination();
-        m_prevWaypointRadius = waypMsg->prevRadius();
-    }
-}
+        //Martins: Pass only WaypointDataMsg here
+        void LineFollowNode::setPrevWaypointData(WaypointDataMsg* waypMsg, VesselStateMsg* vesselMsg)
+        {
 
-int LineFollowNode::getHeading(int gpsHeading, int compassHeading, double gpsSpeed, bool mockPosition,bool getHeadingFromCompass)
-{
-	//Use GPS for heading only if speed is higher than 1 m/s
-	int useGpsForHeadingMeterSecSpeed = 1;
-	bool gpsForbidden = Utility::directionAdjustedSpeed(gpsHeading, compassHeading, gpsSpeed) < useGpsForHeadingMeterSecSpeed;
+          //Martins: Use the saved state of the StateMessage
+          if(waypMsg->prevId() == 0) //Set previous waypoint to boat position
+          {
+            m_prevWaypointId = 0;
+            m_prevWaypointLon = vesselMsg->longitude();
+            m_prevWaypointLat = vesselMsg->latitude();
+            m_prevWaypointDeclination = 0;
+            m_prevWaypointRadius = 15;
+          }
+          else //Set previous waypoint to previously harvested waypoint
+          {
+            m_prevWaypointId = waypMsg->prevId();
+            m_prevWaypointLon = waypMsg->prevLongitude();
+            m_prevWaypointLat = waypMsg->prevLatitude();
+            m_prevWaypointDeclination = waypMsg->prevDeclination();
+            m_prevWaypointRadius = waypMsg->prevRadius();
+          }
+        }
 
-	getMergedHeading(gpsHeading, compassHeading, true); //decrease compass weight on each iteration
+        int LineFollowNode::getHeading(int gpsHeading, int compassHeading, double gpsSpeed, bool mockPosition,bool getHeadingFromCompass)
+        {
+          //Use GPS for heading only if speed is higher than 1 m/s
+          int useGpsForHeadingMeterSecSpeed = 1;
+          bool gpsForbidden = Utility::directionAdjustedSpeed(gpsHeading, compassHeading, gpsSpeed) < useGpsForHeadingMeterSecSpeed;
 
-    // if(mockPosition) { //TODO - MOCK
-    //     return position->getHeading(); //OUTCOMMENTED FOR NOW UNTIL WE FIGURE OUT MOCK
-    // }
+          getMergedHeading(gpsHeading, compassHeading, true); //decrease compass weight on each iteration
 
-	if (getHeadingFromCompass) {
-		//Should return compass heading if below one knot and not currently merging and vice versa
-    	return Utility::addDeclinationToHeading(getMergedHeading(gpsHeading, compassHeading, gpsForbidden), m_nextWaypointDeclination);
-	}
-    return gpsHeading;
-}
+          // if(mockPosition) { //TODO - MOCK
+          //     return position->getHeading(); //OUTCOMMENTED FOR NOW UNTIL WE FIGURE OUT MOCK
+          // }
 
-int LineFollowNode::getMergedHeading(int gpsHeading, int compassHeading, bool increaseCompassWeight)
-{
-	//Shouldn't be hardcoded
-	float tickRate = 0.01;
+          if (getHeadingFromCompass) {
+            //Should return compass heading if below one knot and not currently merging and vice versa
+            return Utility::addDeclinationToHeading(getMergedHeading(gpsHeading, compassHeading, gpsForbidden), m_nextWaypointDeclination);
+          }
+          return gpsHeading;
+        }
 
-	int headingCompass = Utility::addDeclinationToHeading(compassHeading, m_nextWaypointDeclination);
-	int headingGps = gpsHeading;
+        int LineFollowNode::getMergedHeading(int gpsHeading, int compassHeading, bool increaseCompassWeight)
+        {
+          //Shouldn't be hardcoded
+          float tickRate = 0.01;
 
-	if (increaseCompassWeight){
-		m_gpsHeadingWeight = m_gpsHeadingWeight - tickRate; //Decrease gps weight
-		if (m_gpsHeadingWeight < 0.0) m_gpsHeadingWeight = 0;
-	}else{
-		m_gpsHeadingWeight = m_gpsHeadingWeight + tickRate;
-		if (m_gpsHeadingWeight > 1.0) m_gpsHeadingWeight = 1.0;
-	}
+          int headingCompass = Utility::addDeclinationToHeading(compassHeading, m_nextWaypointDeclination);
+          int headingGps = gpsHeading;
 
-	//Difference calculation
-	float diff = ((headingGps - headingCompass) + 180 + 360);
-	while (diff > 360) diff -= 360;
-	diff -= 180;
+          if (increaseCompassWeight){
+            m_gpsHeadingWeight = m_gpsHeadingWeight - tickRate; //Decrease gps weight
+            if (m_gpsHeadingWeight < 0.0) m_gpsHeadingWeight = 0;
+          }else{
+            m_gpsHeadingWeight = m_gpsHeadingWeight + tickRate;
+            if (m_gpsHeadingWeight > 1.0) m_gpsHeadingWeight = 1.0;
+          }
 
-	//Merge angle calculation
-	int returnValue = 360 + headingCompass + (diff * m_gpsHeadingWeight);
-	while (returnValue > 360) returnValue -= 360;
+          //Difference calculation
+          float diff = ((headingGps - headingCompass) + 180 + 360);
+          while (diff > 360) diff -= 360;
+          diff -= 180;
 
-	return returnValue;
-}
+          //Merge angle calculation
+          int returnValue = 360 + headingCompass + (diff * m_gpsHeadingWeight);
+          while (returnValue > 360) returnValue -= 360;
 
-void LineFollowNode::setupRudderCommand()
-{
-	m_rudderCommand.setCommandValues(m_db.retrieveCellAsInt("rudder_command_config", "1","extreme_command"),
-	        m_db.retrieveCellAsInt("rudder_command_config", "1", "midship_command"));
-}
+          return returnValue;
+        }
 
-void LineFollowNode::setupSailCommand()
-{
-	m_sailCommand.setCommandValues( m_db.retrieveCellAsInt("sail_command_config", "1", "close_reach_command"),
-	        m_db.retrieveCellAsInt("sail_command_config", "1", "run_command"));
-}
+        void LineFollowNode::setupRudderCommand()
+        {
+          m_rudderCommand.setCommandValues(m_db.retrieveCellAsInt("rudder_command_config", "1","extreme_command"),
+          m_db.retrieveCellAsInt("rudder_command_config", "1", "midship_command"));
+        }
 
-bool LineFollowNode::getGoingStarboard()
-{
-    if(m_tackingDirection == 1) return true;
-    else return false;
-}
+        void LineFollowNode::setupSailCommand()
+        {
+          m_sailCommand.setCommandValues( m_db.retrieveCellAsInt("sail_command_config", "1", "close_reach_command"),
+          m_db.retrieveCellAsInt("sail_command_config", "1", "run_command"));
+        }
 
-void LineFollowNode::setPrevWaypointToBoatPos(VesselStateMsg* msg) //If boat passed waypoint or enters it, set new line from boat to waypoint.
-{                                                                  //Used if boat has to stay within waypoint for a set amount of time.
-    double distanceAfterWaypoint = Utility::calculateWaypointsOrthogonalLine(m_nextWaypointLon, m_nextWaypointLat, m_prevWaypointLon,
+        bool LineFollowNode::getGoingStarboard()
+        {
+          if(m_tackingDirection == 1) return true;
+          else return false;
+        }
+
+        //Martins: Use the StateMessage and WaypointDataMsg Saved so do not send any message type here
+        void LineFollowNode::setPrevWaypointToBoatPos(VesselStateMsg* msg) //If boat passed waypoint or enters it, set new line from boat to waypoint.
+        {                                                                  //Used if boat has to stay within waypoint for a set amount of time.
+          double distanceAfterWaypoint = Utility::calculateWaypointsOrthogonalLine(m_nextWaypointLon, m_nextWaypointLat, m_prevWaypointLon,
             m_prevWaypointLat, msg->longitude(), msg->latitude());
 
-    double DTW = CourseMath::calculateDTW(msg->longitude(), msg->latitude(), m_nextWaypointLon, m_nextWaypointLat);
+            double DTW = CourseMath::calculateDTW(msg->longitude(), msg->latitude(), m_nextWaypointLon, m_nextWaypointLat);
 
-    if(distanceAfterWaypoint > 0 ||  DTW < m_nextWaypointRadius)
-    {
-        m_prevWaypointLon = msg->longitude();
-        m_prevWaypointLat = msg->latitude();
-    }
-}
+            if(distanceAfterWaypoint > 0 ||  DTW < m_nextWaypointRadius)
+            {
+              m_prevWaypointLon = msg->longitude();
+              m_prevWaypointLat = msg->latitude();
+            }
+          }

--- a/Nodes/LineFollowNode.cpp
+++ b/Nodes/LineFollowNode.cpp
@@ -124,7 +124,7 @@ void LineFollowNode::processMessage(const Message* msg)
       m_nextWaypointLat = waypMsg->nextLatitude();
       m_nextWaypointDeclination = waypMsg->nextDeclination();
       m_nextWaypointRadius = waypMsg->nextRadius();
-      setPrevWaypointData(waypMsg, (VesselStateMsg*)msg);
+      setPrevWaypointData(waypMsg);
     }
     break;
     default:
@@ -270,15 +270,15 @@ double LineFollowNode::calculateAngleOfDesiredTrajectory(VesselStateMsg* msg)
         }
 
         //Martins: Pass only WaypointDataMsg here
-        void LineFollowNode::setPrevWaypointData(WaypointDataMsg* waypMsg, VesselStateMsg* vesselMsg)
+        void LineFollowNode::setPrevWaypointData(WaypointDataMsg* waypMsg)
         {
 
           //Martins: Use the saved state of the StateMessage
           if(waypMsg->prevId() == 0) //Set previous waypoint to boat position
           {
             m_prevWaypointId = 0;
-            m_prevWaypointLon = vesselMsg->longitude();
-            m_prevWaypointLat = vesselMsg->latitude();
+            m_prevWaypointLon = m_VesselLon;
+            m_prevWaypointLat = m_VesselLat;
             m_prevWaypointDeclination = 0;
             m_prevWaypointRadius = 15;
           }

--- a/Nodes/LineFollowNode.h
+++ b/Nodes/LineFollowNode.h
@@ -1,19 +1,19 @@
- /****************************************************************************************
- *
- * File:
- * 		LineFollowNode.h
- *
- * Purpose:
- *		This class computes the actuator positions of the boat in order to follow
- *    lines given by the waypoints.
- *
- * Developer Notes: algorithm inspired and modified from Luc Jaulin and
- *    Fabrice Le Bars  "An Experimental Validation of a Robust Controller with the VAIMOS
- *    Autonomous Sailboat" and "Modeling and Control for an Autonomous Sailboat: A
- *    Case Study" from Jon Melin, Kjell Dahl and Matia Waller
- *
- *
- ***************************************************************************************/
+/****************************************************************************************
+*
+* File:
+* 		LineFollowNode.h
+*
+* Purpose:
+*		This class computes the actuator positions of the boat in order to follow
+*    lines given by the waypoints.
+*
+* Developer Notes: algorithm inspired and modified from Luc Jaulin and
+*    Fabrice Le Bars  "An Experimental Validation of a Robust Controller with the VAIMOS
+*    Autonomous Sailboat" and "Modeling and Control for an Autonomous Sailboat: A
+*    Case Study" from Jon Melin, Kjell Dahl and Matia Waller
+*
+*
+***************************************************************************************/
 
 #pragma once
 
@@ -47,8 +47,7 @@ private:
 	double 	m_nextWaypointLat;
 	int 	m_nextWaypointDeclination;
 	int 	m_nextWaypointRadius;
-
-    int 	m_prevWaypointId;
+	int 	m_prevWaypointId;
 	double 	m_prevWaypointLon;
 	double 	m_prevWaypointLat;
 	int 	m_prevWaypointDeclination;
@@ -56,10 +55,25 @@ private:
 
 	bool 	m_externalControlActive;
 
-    bool    m_tack;
-    double  m_maxCommandAngle, m_maxSailAngle, m_minSailAngle;
-    double  m_tackAngle;
-    int     m_tackingDirection;
+	bool    m_tack;
+	double  m_maxCommandAngle, m_maxSailAngle, m_minSailAngle;
+	double  m_tackAngle;
+	int     m_tackingDirection;
+
+	//same as compass heading
+	float 	m_VesselHeading;
+
+	double	m_VesselLat;
+	double	m_VesselLon;
+	double	m_VesselSpeed;
+
+	//same as the gpsheading
+	double  m_VesselCourse;
+
+	double m_trueWindSpeed;
+	double m_trueWindDir;
+	double m_apparentWindSpeed;
+	double m_apparentWindDir;
 
 	RudderCommand m_rudderCommand;
 	SailCommand m_sailCommand;
@@ -67,18 +81,18 @@ private:
 	std::vector<float> twdBuffer;
 	unsigned int twdBufferMaxSize;
 
-    double calculateAngleOfDesiredTrajectory(VesselStateMsg* msg);
+	double calculateAngleOfDesiredTrajectory(VesselStateMsg* msg);
 	void calculateActuatorPos(VesselStateMsg* msg);
-    void setPrevWaypointData(WaypointDataMsg* waypMsg, VesselStateMsg* vesselMsg);
+	void setPrevWaypointData(WaypointDataMsg* waypMsg, VesselStateMsg* vesselMsg);
 
 	virtual int getHeading(int gpsHeading, int compassHeading, double gpsSpeed, bool mockPosition, bool getHeadingFromCompass);
-  //Calculates a smooth transition between the compass and the gps. Do not call directly, use getHeading()
+	//Calculates a smooth transition between the compass and the gps. Do not call directly, use getHeading()
 	int getMergedHeading(int gpsHeading, int compassHeading, bool increaseCompassWeight);
 	void setupRudderCommand();
 	void setupSailCommand();
-    bool getGoingStarboard();
+	bool getGoingStarboard();
 	void setPrevWaypointToBoatPos(VesselStateMsg* msg);
 
 	/*void manageDatabase(VesselStateMsg* msg, double trueWindDirection, double rudder, double sail, double heading,
-                        double distanceToNextWaypoint, double bearingToNextWaypoint);*/
+	double distanceToNextWaypoint, double bearingToNextWaypoint);*/
 };

--- a/Nodes/LineFollowNode.h
+++ b/Nodes/LineFollowNode.h
@@ -83,7 +83,7 @@ private:
 
 	double calculateAngleOfDesiredTrajectory(VesselStateMsg* msg);
 	void calculateActuatorPos(VesselStateMsg* msg);
-	void setPrevWaypointData(WaypointDataMsg* waypMsg, VesselStateMsg* vesselMsg);
+	void setPrevWaypointData(WaypointDataMsg* waypMsg);
 
 	virtual int getHeading(int gpsHeading, int compassHeading, double gpsSpeed, bool mockPosition, bool getHeadingFromCompass);
 	//Calculates a smooth transition between the compass and the gps. Do not call directly, use getHeading()

--- a/Nodes/LineFollowNode.h
+++ b/Nodes/LineFollowNode.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include "Node.h"
-#include "Messages/VesselStateMsg.h"
 #include "Messages/StateMessage.h"
 #include "Messages/WindStateMsg.h"
 #include "Messages/WaypointDataMsg.h"
@@ -62,14 +61,10 @@ private:
 	double  m_tackAngle;
 	int     m_tackingDirection;
 
-	//same as compass heading
 	float 	m_Heading;
-
 	double	m_Latitude;
 	double	m_Longitude;
 	double	m_Speed;
-
-	//same as the gpsheading
 	double  m_Course;
 
 	double m_trueWindSpeed;

--- a/Nodes/LineFollowNode.h
+++ b/Nodes/LineFollowNode.h
@@ -61,14 +61,14 @@ private:
 	int     m_tackingDirection;
 
 	//same as compass heading
-	float 	m_VesselHeading;
+	float 	m_Heading;
 
-	double	m_VesselLat;
-	double	m_VesselLon;
-	double	m_VesselSpeed;
+	double	m_Latitude;
+	double	m_Longitude;
+	double	m_Speed;
 
 	//same as the gpsheading
-	double  m_VesselCourse;
+	double  m_Course;
 
 	double m_trueWindSpeed;
 	double m_trueWindDir;
@@ -81,7 +81,7 @@ private:
 	std::vector<float> twdBuffer;
 	unsigned int twdBufferMaxSize;
 
-	double calculateAngleOfDesiredTrajectory(VesselStateMsg* msg);
+	double calculateAngleOfDesiredTrajectory();
 	void calculateActuatorPos(VesselStateMsg* msg);
 	void setPrevWaypointData(WaypointDataMsg* waypMsg);
 

--- a/Nodes/LineFollowNode.h
+++ b/Nodes/LineFollowNode.h
@@ -19,6 +19,8 @@
 
 #include "Node.h"
 #include "Messages/VesselStateMsg.h"
+#include "Messages/StateMessage.h"
+#include "Messages/WindStateMsg.h"
 #include "Messages/WaypointDataMsg.h"
 #include "dbhandler/DBHandler.h"
 #include "dbhandler/DBLogger.h"
@@ -82,7 +84,7 @@ private:
 	unsigned int twdBufferMaxSize;
 
 	double calculateAngleOfDesiredTrajectory();
-	void calculateActuatorPos(VesselStateMsg* msg);
+	void calculateActuatorPos(const WindStateMsg* msg);
 	void setPrevWaypointData(WaypointDataMsg* waypMsg);
 
 	virtual int getHeading(int gpsHeading, int compassHeading, double gpsSpeed, bool mockPosition, bool getHeadingFromCompass);
@@ -91,7 +93,7 @@ private:
 	void setupRudderCommand();
 	void setupSailCommand();
 	bool getGoingStarboard();
-	void setPrevWaypointToBoatPos(VesselStateMsg* msg);
+	void setPrevWaypointToBoatPos();
 
 	/*void manageDatabase(VesselStateMsg* msg, double trueWindDirection, double rudder, double sail, double heading,
 	double distanceToNextWaypoint, double bearingToNextWaypoint);*/

--- a/Tests/unit-tests/LineFollowSuite.h
+++ b/Tests/unit-tests/LineFollowSuite.h
@@ -18,6 +18,8 @@
 #include "TestMocks/MessageLogger.h"
 #include "Nodes/LineFollowNode.h"
 #include "Messages/VesselStateMsg.h"
+#include "Messages/WindStateMsg.h"
+#include "Messages/StateMessage.h"
 
 // For std::this_thread
 #include <chrono>
@@ -80,8 +82,11 @@ class LineFollowSuite : public CxxTest::TestSuite {
     void test_LineFollowCalculateActuatorPosition()
     {
 
-        MessagePtr msg = std::make_unique<VesselStateMsg>(170, 30, 0, true, true, 19.2, 60.02, 120.04, 2.1, 11, 170, 23.5f, 5.4f, 24.5f, 10, 5500, 4700, 2, 3);
+        MessagePtr msg = std::make_unique<WindStateMsg>(170, 30, 0, 200);
+        MessagePtr sMsg = std::make_unique<StateMessage>(170, 30, 10, 200, 50);
+
         msgBus().sendMessage(std::move(msg));
+        msgBus().sendMessage(std::move(sMsg));
 
         std::this_thread::sleep_for(std::chrono::milliseconds(2000));
 		TS_TRACE("END OF LINEFOLLOW");

--- a/dbhandler/DBHandler.h
+++ b/dbhandler/DBHandler.h
@@ -7,7 +7,7 @@
 #include <vector>
 #include <sqlite3.h>
 #include "SystemServices/Logger.h"
-#include "Messages/VesselStateMsg.h"
+#include "Messages/WindStateMsg.h"
 #include <mutex>
 #include "libs/json/src/json.hpp"
 using Json = nlohmann::json;

--- a/dbhandler/DBLogger.cpp
+++ b/dbhandler/DBLogger.cpp
@@ -52,13 +52,17 @@ void DBLogger::startWorkerThread()
 	m_thread = new std::thread(workerThread, this);
 }
 
-void DBLogger::log(VesselStateMsg* msg, double rudder, double sail, int sailServoPosition, int rudderServoPosition,
+void DBLogger::log(const WindStateMsg* msg, double rudder, double sail, int sailServoPosition, int rudderServoPosition,
 		double distanceToWaypoint, double bearingToWaypoint, double courseToSteer, bool tack, bool goingStarboard,
 		int waypointId, double twd, bool routeStarted,std::string timestamp_str)
 {
 	LogItem item;
 
-	item.m_compassHeading = msg->compassHeading();
+ /*
+	*	NOTE: Some code block are been commented out because the properties used
+  *	in them are not available in msg any longer.
+	*/
+	/*item.m_compassHeading = msg->compassHeading();
 	item.m_compassPitch = msg->compassPitch();
 	item.m_compassRoll = msg->compassRoll();
 	item.m_gpsHasFix = msg->gpsHasFix();
@@ -75,7 +79,7 @@ void DBLogger::log(VesselStateMsg* msg, double rudder, double sail, int sailServ
 	item.m_arduinoPressure = msg->arduinoPressure();
 	item.m_arduinoRudder = msg->arduinoPressure();
 	item.m_arduinoSheet = msg->arduinoSheet();
-	item.m_arduinoBattery = msg->arduinoBattery();
+	item.m_arduinoBattery = msg->arduinoBattery();*/
 	item.m_rudder = setValue<double>(rudder);
 	item.m_sail = setValue<double>(sail);
 	item.m_sailServoPosition = sailServoPosition;

--- a/dbhandler/DBLogger.h
+++ b/dbhandler/DBLogger.h
@@ -30,7 +30,7 @@ public:
 
 	void startWorkerThread();
 
-	void log(VesselStateMsg* msg, double rudder, double sail, int sailServoPosition, int rudderServoPosition,
+	void log(const WindStateMsg* msg, double rudder, double sail, int sailServoPosition, int rudderServoPosition,
 			double courseCalculationDistanceToWaypoint, double courseCalculationBearingToWaypoint,
 			double courseCalculationCourseToSteer, bool courseCalculationTack, bool courseCalculationGoingStarboard,
 			int waypointId, double trueWindDirectionCalc, bool routeStarted,std::string timestamp_str);
@@ -40,7 +40,7 @@ private:
 
 	template<typename FloatOrDouble>
 	FloatOrDouble setValue(FloatOrDouble value);
-	
+
 	static void workerThread(DBLogger* ptr);
 
 	std::thread* 			m_thread;


### PR DESCRIPTION
LineFollowNode is now using StateMessage and WindStateMessage instead of VesselStateMessage.

Some variables are no longer able to be saved to the log using DBLogger.log() these variables have been commented out and should be saved to the log from another node.