### PR TITLE
Srcs 391

### DIFF
--- a/NavigationSystem/Hardwares/ActuatorNodeJanet.cpp
+++ b/NavigationSystem/Hardwares/ActuatorNodeJanet.cpp
@@ -12,13 +12,12 @@
  ***************************************************************************************/
 
 #include "Hardwares/ActuatorNodeJanet.h"
-//#include "Messages/ActuatorPositionMsg.h"
 #include "Messages/JanetActuatorFeedbackMsg.h"
 #include "Hardwares/MaestroController/MaestroController.h"
 #include "SystemServices/Logger.h"
 
 
-ActuatorNodeJanet::ActuatorNodeJanet(MessageBus& msgBus, DBHandler& dbhandler, NodeID id, int channel, int speed, int acceleration)
+ActuatorNodeJanet::ActuatorNodeJanet(MessageBus& msgBus, NodeID id, int channel, int speed, int acceleration)
 	:Node(id, msgBus), m_Channel(channel), m_Speed(speed), m_Acceleration(acceleration), m_db(dbhandler)
 {
   msgBus.registerNode(*this,MessageType::JanetActuatorFeedback);

--- a/NavigationSystem/Hardwares/ActuatorNodeJanet.cpp
+++ b/NavigationSystem/Hardwares/ActuatorNodeJanet.cpp
@@ -1,7 +1,7 @@
 /****************************************************************************************
  *
  * File:
- * 		ActuatorNode.cpp
+ * 		ActuatorNodeJanet.cpp
  *
  * Purpose:
  *		Controls an actuator on the vessel.
@@ -11,20 +11,20 @@
  *
  ***************************************************************************************/
 
-#include "Hardwares/ActuatorNode.h"
+#include "Hardwares/ActuatorNodeJanet.h"
 #include "Messages/ActuatorPositionMsg.h"
 #include "Hardwares/MaestroController/MaestroController.h"
 #include "SystemServices/Logger.h"
 
 
-ActuatorNode::ActuatorNode(MessageBus& msgBus, DBHandler& dbhandler, NodeID id, int channel, int speed, int acceleration)
+ActuatorNodeJanet::ActuatorNodeJanet(MessageBus& msgBus, DBHandler& dbhandler, NodeID id, int channel, int speed, int acceleration)
 	:Node(id, msgBus), m_Channel(channel), m_Speed(speed), m_Acceleration(acceleration), m_db(dbhandler)
 {
   msgBus.registerNode(*this,MessageType::ActuatorPosition);
   msgBus.registerNode(*this,MessageType::ServerConfigsReceived);
 }
 
-bool ActuatorNode::init()
+bool ActuatorNodeJanet::init()
 {
 	if( MaestroController::writeCommand(MaestroCommands::SetSpeed, m_Channel, m_Speed) &&
 		MaestroController::writeCommand(MaestroCommands::SetAcceleration, m_Channel, m_Acceleration) )
@@ -39,7 +39,7 @@ bool ActuatorNode::init()
 
 }
 
-void ActuatorNode::processMessage(const Message* message)
+void ActuatorNodeJanet::processMessage(const Message* message)
 {
 	if(message->messageType() == MessageType::ActuatorPosition)
 	{

--- a/NavigationSystem/Hardwares/ActuatorNodeJanet.cpp
+++ b/NavigationSystem/Hardwares/ActuatorNodeJanet.cpp
@@ -12,7 +12,8 @@
  ***************************************************************************************/
 
 #include "Hardwares/ActuatorNodeJanet.h"
-#include "Messages/ActuatorPositionMsg.h"
+//#include "Messages/ActuatorPositionMsg.h"
+#include "Messages/JanetActuatorFeedbackMsg.h"
 #include "Hardwares/MaestroController/MaestroController.h"
 #include "SystemServices/Logger.h"
 
@@ -20,7 +21,7 @@
 ActuatorNodeJanet::ActuatorNodeJanet(MessageBus& msgBus, DBHandler& dbhandler, NodeID id, int channel, int speed, int acceleration)
 	:Node(id, msgBus), m_Channel(channel), m_Speed(speed), m_Acceleration(acceleration), m_db(dbhandler)
 {
-  msgBus.registerNode(*this,MessageType::ActuatorPosition);
+  msgBus.registerNode(*this,MessageType::JanetActuatorFeedback);
   msgBus.registerNode(*this,MessageType::ServerConfigsReceived);
 }
 
@@ -41,20 +42,20 @@ bool ActuatorNodeJanet::init()
 
 void ActuatorNodeJanet::processMessage(const Message* message)
 {
-	if(message->messageType() == MessageType::ActuatorPosition)
+	if(message->messageType() == MessageType::JanetActuatorFeedback)
 	{
-		ActuatorPositionMsg* msg = (ActuatorPositionMsg*)message;
+		JanetActuatorFeedbackMsg* msg = (JanetActuatorFeedbackMsg*)message;
 
 		//Get relevant command
 		int setPosition = 0;
 
 		if (nodeID() == NodeID::RudderActuator)
 		{
-			setPosition = msg->rudderPosition();
+			setPosition = msg->rudderFeedback();
 		}
 		else if (nodeID() == NodeID::SailActuator)
 		{
-			setPosition = msg->sailPosition();
+			setPosition = msg->wingsailFeedback();
 		}
 		else
 		{

--- a/NavigationSystem/Hardwares/ActuatorNodeJanet.h
+++ b/NavigationSystem/Hardwares/ActuatorNodeJanet.h
@@ -1,7 +1,7 @@
 /****************************************************************************************
  *
  * File:
- * 		ActuatorNode.h
+ * 		ActuatorNodeJanet.h
  *
  * Purpose:
  *		Controls an actuator on the vessel.
@@ -16,9 +16,9 @@
 #include "MessageBus/Node.h"
 #include "DataBase/DBHandler.h"
 
-class ActuatorNode : public Node {
+class ActuatorNodeJanet : public Node {
 public:
-	ActuatorNode(MessageBus& msgBus, DBHandler& dbhandler, NodeID id, int channel, int speed, int acceleration);
+	ActuatorNodeJanet(MessageBus& msgBus, DBHandler& dbhandler, NodeID id, int channel, int speed, int acceleration);
 
 	///----------------------------------------------------------------------------------
  	/// Setups the actuator.

--- a/NavigationSystem/Hardwares/ActuatorNodeJanet.h
+++ b/NavigationSystem/Hardwares/ActuatorNodeJanet.h
@@ -18,7 +18,7 @@
 
 class ActuatorNodeJanet : public Node {
 public:
-	ActuatorNodeJanet(MessageBus& msgBus, DBHandler& dbhandler, NodeID id, int channel, int speed, int acceleration);
+	ActuatorNodeJanet(MessageBus& msgBus, NodeID id, int channel, int speed, int acceleration);
 
 	///----------------------------------------------------------------------------------
  	/// Setups the actuator.
@@ -36,5 +36,4 @@ private:
 	int m_Channel;
 	int m_Speed;
 	int m_Acceleration;
-	DBHandler& m_db;
 };

--- a/NavigationSystem/MessageBus/MessageTypes.h
+++ b/NavigationSystem/MessageBus/MessageTypes.h
@@ -40,6 +40,7 @@ enum class MessageType {
 	WindState,
 	LocalNavigation,
 	ASPireActuatorFeedback,
+	JanetActuatorFeedback,
 	MarineSensorData,
 	AISData,
 	WingSailCommand,
@@ -93,6 +94,8 @@ inline std::string msgToString(MessageType msgType)
 		return "LocalNavigation";
 		case MessageType::ASPireActuatorFeedback:
 		return "ASPireActuatorFeedback";
+		case MessageType::JanetActuatorFeedback:
+		return "JanetActuatorFeedback";
 		case MessageType::MarineSensorData:
 		return "MarineSensorData";
 		case MessageType::AISData:

--- a/NavigationSystem/Messages/JanetActuatorFeedbackMsg.h
+++ b/NavigationSystem/Messages/JanetActuatorFeedbackMsg.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "MessageBus/Message.h"
+
+
+class JanetActuatorFeedbackMsg : public Message {
+public:
+    JanetActuatorFeedbackMsg(NodeID sourceID, NodeID destinationID, double wingsailFeedback,
+                                double rudderFeedback, double windvaneAngle, double windvaneActuatorPos, bool radioControllerOn)
+    : Message(MessageType::JanetActuatorFeedback, sourceID, destinationID),
+    m_WingsailFeedback(wingsailFeedback), m_RudderFeedback(rudderFeedback),
+    m_WindvaneSelfSteeringAngle(windvaneAngle), m_WindvaneActuatorPosition(windvaneActuatorPos), m_RadioControllerOn(radioControllerOn)
+    {  }
+
+    JanetActuatorFeedbackMsg( double wingsailFeedback, double rudderFeedback,
+                                   double windvaneAngle, double windvaneActuatorPos, bool radioControllerOn)
+    : Message(MessageType::JanetActuatorFeedback, NodeID::None, NodeID::None),
+    m_WingsailFeedback(wingsailFeedback), m_RudderFeedback(rudderFeedback),
+    m_WindvaneSelfSteeringAngle(windvaneAngle), m_WindvaneActuatorPosition(windvaneActuatorPos), m_RadioControllerOn(radioControllerOn)
+    {  }
+
+    virtual ~JanetActuatorFeedbackMsg() { }
+
+    double wingsailFeedback() const          { return m_WingsailFeedback; }
+    double rudderFeedback() const            { return m_RudderFeedback; }
+    double windvaneSelfSteeringAngle() const { return m_WindvaneSelfSteeringAngle; }
+    double windvaneActuatorPosition()  const { return m_WindvaneActuatorPosition; }
+	bool radioControllerOn() 				   const { return m_RadioControllerOn; }
+
+private:
+    double m_WingsailFeedback;          // degree in wing sail reference frame (clockwise from top view)
+    double m_RudderFeedback;            // degree in vessel reference frame (clockwise from top view)
+    double m_WindvaneSelfSteeringAngle; // degree
+    double m_WindvaneActuatorPosition;
+	bool   m_RadioControllerOn;
+};

--- a/NavigationSystem/Messages/JanetActuatorFeedbackMsg.h
+++ b/NavigationSystem/Messages/JanetActuatorFeedbackMsg.h
@@ -19,13 +19,23 @@ public:
     m_WindvaneSelfSteeringAngle(windvaneAngle), m_WindvaneActuatorPosition(windvaneActuatorPos), m_RadioControllerOn(radioControllerOn)
     {  }
 
+    JanetActuatorFeedbackMsg(MessageDeserialiser deserialiser)
+            :Message(deserialiser)
+    {
+        if( !deserialiser.readDouble(m_RudderFeedback) ||
+            !deserialiser.readDouble(m_WingsailFeedback))
+        {
+            m_valid = false;
+        }
+    }
+
     virtual ~JanetActuatorFeedbackMsg() { }
 
     double wingsailFeedback() const          { return m_WingsailFeedback; }
     double rudderFeedback() const            { return m_RudderFeedback; }
     double windvaneSelfSteeringAngle() const { return m_WindvaneSelfSteeringAngle; }
     double windvaneActuatorPosition()  const { return m_WindvaneActuatorPosition; }
-	bool radioControllerOn() 				   const { return m_RadioControllerOn; }
+	bool radioControllerOn() 	       const { return m_RadioControllerOn; }
 
 private:
     double m_WingsailFeedback;          // degree in wing sail reference frame (clockwise from top view)

--- a/NavigationSystem/Tests/unit-tests/ActuatorRudderNodeSuite.h
+++ b/NavigationSystem/Tests/unit-tests/ActuatorRudderNodeSuite.h
@@ -21,7 +21,7 @@
 
  #include "../cxxtest/cxxtest/TestSuite.h"
  #include "TestMocks/MessageLogger.h"
- #include "Hardwares/ActuatorNode.h"
+ #include "Hardwares/ActuatorNodeJanet.h"
  #include "Hardwares/MaestroController/MaestroController.h"
 
 // For std::this_thread
@@ -33,7 +33,7 @@
 
  class ActuatorRudderNodeSuite : public CxxTest::TestSuite {
     public:
-    ActuatorNode* rudder;
+    ActuatorNodeJanet* rudder;
     DBHandler* dbhandler;
     MessageLogger* logger;
     std::thread* thr;
@@ -61,7 +61,7 @@
 			logger = new MessageLogger(msgBus());
             dbhandler = new DBHandler("../asr.db");
             int channel = 3, speed = 0, acceleration = 0;
-			rudder = new ActuatorNode(msgBus(), *dbhandler, NodeID::RudderActuator, channel, speed, acceleration);
+			rudder = new ActuatorNodeJanet(msgBus(), *dbhandler, NodeID::RudderActuator, channel, speed, acceleration);
             thr = new std::thread(runMessageLoop);
 		}
 		testCount++;

--- a/NavigationSystem/Tests/unit-tests/ActuatorSailNodeSuite.h
+++ b/NavigationSystem/Tests/unit-tests/ActuatorSailNodeSuite.h
@@ -22,7 +22,7 @@
  #include "../cxxtest/cxxtest/TestSuite.h"
  #include "../../MessageBus/MessageBus.h"
  #include "TestMocks/MessageLogger.h"
- #include "Hardwares/ActuatorNode.h"
+ #include "Hardwares/ActuatorNodeJanet.h"
  #include "Hardwares/MaestroController/MaestroController.h"
 
 // For std::this_thread
@@ -34,7 +34,7 @@
 
  class ActuatorSailNodeSuite : public CxxTest::TestSuite {
     public:
-    ActuatorNode* wingsail;
+    ActuatorNodeJanet* wingsail;
     DBHandler* dbhandler;
     MessageLogger* logger;
     std::thread* thr;
@@ -62,7 +62,7 @@
 			logger = new MessageLogger(msgBus());
             dbhandler = new DBHandler("../asr.db");
             int channel = 3, speed = 0, acceleration = 0;
-			wingsail = new ActuatorNode(msgBus(), *dbhandler, NodeID::SailActuator, channel, speed, acceleration);
+			wingsail = new ActuatorNodeJanet(msgBus(), *dbhandler, NodeID::SailActuator, channel, speed, acceleration);
             thr = new std::thread(runMessageLoop);
 		}
 		testCount++;

--- a/NavigationSystem/Xbee/XbeeSyncNode.cpp
+++ b/NavigationSystem/Xbee/XbeeSyncNode.cpp
@@ -37,9 +37,7 @@ XbeeSyncNode::XbeeSyncNode(MessageBus& msgBus, DBHandler& db) :
 	m_node = this;
 }
 
-/*XbeeSyncNode::~XbeeSyncNode() { // Must be define because the destructor has been declared virtual
-
-} */
+//XbeeSyncNode::~XbeeSyncNode() {}
 
 bool XbeeSyncNode::init()
 {
@@ -117,9 +115,9 @@ void XbeeSyncNode::incomingMessage(uint8_t* data, uint8_t size)
 
 	switch(msg.messageType())
 	{
-		case MessageType::ActuatorPosition:
+		case MessageType::JanetActuatorFeedback:
 			{
-				MessagePtr actuatorControl = std::make_unique<ActuatorPositionMsg>(deserialiser);
+				MessagePtr actuatorControl = std::make_unique<JanetActuatorFeedbackMsg>(deserialiser);
 				m_node->m_MsgBus.sendMessage(std::move(actuatorControl));
 				Logger::info("Actuator received");
 			}

--- a/NavigationSystem/Xbee/XbeeSyncNode.cpp
+++ b/NavigationSystem/Xbee/XbeeSyncNode.cpp
@@ -37,8 +37,6 @@ XbeeSyncNode::XbeeSyncNode(MessageBus& msgBus, DBHandler& db) :
 	m_node = this;
 }
 
-//XbeeSyncNode::~XbeeSyncNode() {}
-
 bool XbeeSyncNode::init()
 {
 	m_initialised = false;

--- a/NavigationSystem/Xbee/XbeeSyncNode.cpp
+++ b/NavigationSystem/Xbee/XbeeSyncNode.cpp
@@ -18,7 +18,7 @@
 #include <cstring>
 
 #include "Messages/ExternalControlMsg.h"
-#include "Messages/ActuatorPositionMsg.h"
+#include "Messages/JanetActuatorFeedbackMsg.h"
 
 #include "SystemServices/Timer.h"
 
@@ -36,6 +36,10 @@ XbeeSyncNode::XbeeSyncNode(MessageBus& msgBus, DBHandler& db) :
 	msgBus.registerNode(*this, MessageType::ServerConfigsReceived);
 	m_node = this;
 }
+
+/*XbeeSyncNode::~XbeeSyncNode() { // Must be define because the destructor has been declared virtual
+
+} */
 
 bool XbeeSyncNode::init()
 {

--- a/NavigationSystem/Xbee/XbeeSyncNode.h
+++ b/NavigationSystem/Xbee/XbeeSyncNode.h
@@ -23,12 +23,13 @@
 #include "Messages/VesselStateMsg.h"
 #include "Network/XbeePacketNetwork.h"
 #include "Network/LinuxSerialDataLink.h"
-
+asdasdasdasdasd
 
 class XbeeSyncNode : public ActiveNode {
 public:
 	XbeeSyncNode(MessageBus& msgBus, DBHandler& db);
-	virtual ~XbeeSyncNode(){}
+	//virtual ~XbeeSyncNode() {}
+	//virtual ~XbeeSyncNode() = 0;
 
 	///----------------------------------------------------------------------------------
 	/// Gets all settings from database and initializes xbee object

--- a/NavigationSystem/Xbee/XbeeSyncNode.h
+++ b/NavigationSystem/Xbee/XbeeSyncNode.h
@@ -23,13 +23,12 @@
 #include "Messages/VesselStateMsg.h"
 #include "Network/XbeePacketNetwork.h"
 #include "Network/LinuxSerialDataLink.h"
-asdasdasdasdasd
+
 
 class XbeeSyncNode : public ActiveNode {
 public:
 	XbeeSyncNode(MessageBus& msgBus, DBHandler& db);
-	//virtual ~XbeeSyncNode() {}
-	//virtual ~XbeeSyncNode() = 0;
+	virtual ~XbeeSyncNode() {}
 
 	///----------------------------------------------------------------------------------
 	/// Gets all settings from database and initializes xbee object

--- a/NavigationSystem/main_janet.cpp
+++ b/NavigationSystem/main_janet.cpp
@@ -32,7 +32,7 @@
   #include "Hardwares/CV7Node.h"
   #include "Hardwares/HMC6343Node.h"
   #include "Hardwares/GPSDNode.h"
-  #include "Hardwares/ActuatorNodeJanet.h" // NOTE - Maël: It will change (to ActuatorNodeJanet.h)
+  #include "Hardwares/ActuatorNodeJanet.h"
   #include "Hardwares/MaestroController/MaestroController.h"
   #include "Xbee/Xbee.h"
   #include "Xbee/XbeeSyncNode.h"
@@ -182,12 +182,12 @@ int main(int argc, char *argv[])
 		int channel = 3;
 		int speed = 0;
 		int acceleration = 0;
-		ActuatorNodeJanet sail(messageBus, NodeID::SailActuator, channel, speed, acceleration);
+		ActuatorNodeJanet sail(messageBus, dbHandler, NodeID::SailActuator, channel, speed, acceleration);
 
 		channel = 4;
 		speed = 0;
 		acceleration = 0;
-		ActuatorNodeJanet rudder(messageBus, NodeID::RudderActuator, channel, speed, acceleration);
+		ActuatorNodeJanet rudder(messageBus, dbHandler, NodeID::RudderActuator, channel, speed, acceleration);
 
 		MaestroController::init(dbHandler.retrieveCell("config_maestro_controller", "1", "port"));
 

--- a/NavigationSystem/main_janet.cpp
+++ b/NavigationSystem/main_janet.cpp
@@ -32,7 +32,7 @@
   #include "Hardwares/CV7Node.h"
   #include "Hardwares/HMC6343Node.h"
   #include "Hardwares/GPSDNode.h"
-  #include "Hardwares/ActuatorNode.h" // NOTE - Maël: It will change (to ActuatorNodeJanet.h)
+  #include "Hardwares/ActuatorNodeJanet.h" // NOTE - Maël: It will change (to ActuatorNodeJanet.h)
   #include "Hardwares/MaestroController/MaestroController.h"
   #include "Xbee/Xbee.h"
   #include "Xbee/XbeeSyncNode.h"
@@ -182,12 +182,12 @@ int main(int argc, char *argv[])
 		int channel = 3;
 		int speed = 0;
 		int acceleration = 0;
-		ActuatorNode sail(messageBus, NodeID::SailActuator, channel, speed, acceleration);
+		ActuatorNodeJanet sail(messageBus, NodeID::SailActuator, channel, speed, acceleration);
 
 		channel = 4;
 		speed = 0;
 		acceleration = 0;
-		ActuatorNode rudder(messageBus, NodeID::RudderActuator, channel, speed, acceleration);
+		ActuatorNodeJanet rudder(messageBus, NodeID::RudderActuator, channel, speed, acceleration);
 
 		MaestroController::init(dbHandler.retrieveCell("config_maestro_controller", "1", "port"));
 

--- a/NavigationSystem/makefile
+++ b/NavigationSystem/makefile
@@ -132,7 +132,7 @@ export CAN_SERVICES_SRC 	= Hardwares/CAN_Services/CANPGNReceiver.cpp Hardwares/C
 							   	Hardwares/CAN_Services/mcp2515.cpp Hardwares/CAN_Services/MsgFunctions.cpp \
 							   	Hardwares/CAN_Services/CANFrameReceiver.cpp
 
-export HW_SERVICES_JANET_SRC = Hardwares/MaestroController/MaestroController.cpp
+export HW_SERVICES_JANET_SRC = Hardwares/MaestroController/MaestroController.cpp Hardwares/ActuatorNodeJanet.cpp
 
 # Hardware nodes
 export HW_NODES_ALL_SRC		= Hardwares/HMC6343Node.cpp Hardwares/GPSDNode.cpp

--- a/NavigationSystem/makefile
+++ b/NavigationSystem/makefile
@@ -146,7 +146,7 @@ export HW_NODES_JANET_SRC 	= Hardwares/CV7Node.cpp Hardwares/ArduinoNode.cpp
 
 # XBee network, XbeeSyncNode not compiling, uses removed ActuatorPositionMsg
 export XBEE_NETWORK_SRC     = Network/DataLink.cpp Network/LinuxSerialDataLink.cpp Network/XbeePacketNetwork.cpp \
-                            	Xbee/Xbee.cpp
+                            	Xbee/Xbee.cpp Xbee/XbeeSyncNode.cpp
 
 # CanbusCommon files
 export CANBUS_COMMON_SRC     = Hardwares/CAN_Services/CanBusCommon/CanUtility.cpp Hardwares/CAN_Services/CanBusCommon/CanMessageHandler.cpp


### PR DESCRIPTION
Compiling works only with USE_SIM=1 for Janet.
I added a new message JanetActuatorFeedbackMsg because ActuatorPositionMsg doesn't exist anymore. It's basically a copy of ASPireActuatorFeedback.
Modifying the message to make it actually usable in Janet configuration will be needed. Maybe we can link this step with SRCS-337 .
I tried to debug XBeeSyncNode, with no success.