### PR TITLE
 Log name format fix

### DIFF
--- a/NavigationSystem/SystemServices/Logger.h
+++ b/NavigationSystem/SystemServices/Logger.h
@@ -31,8 +31,8 @@
 #include <iostream>
 #include "sys/stat.h"
 
-#define DEFAULT_LOG_NAME "sailing-log.log"
-#define DEFAULT_LOG_NAME_WRSC "wrsc-log.log"
+#define DEFAULT_LOG_NAME "sailing.log"
+#define DEFAULT_LOG_NAME_WRSC "wrsc.log"
 #define FILE_PATH "../logs/"
 
 class Logger {

--- a/NavigationSystem/SystemServices/SysClock.cpp
+++ b/NavigationSystem/SystemServices/SysClock.cpp
@@ -62,7 +62,7 @@ std::string SysClock::timeStampStr()
 	unsigned long seconds = unixTime();
 
 	time_t unix_time = (time_t)seconds;
-	strftime(buff, sizeof(buff), "%F %T", gmtime(&unix_time));
+	strftime(buff, sizeof(buff), "%F_%T", gmtime(&unix_time));
 
 	return std::string(buff);
 }


### PR DESCRIPTION
fixed a problem where the logs were named -log.log and added a underscore between the date and the time in the name